### PR TITLE
🌈 feat: 유저 팔로우 리스트 생성 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "@types/passport-jwt": "^4.0.0",
         "axios": "^1.6.5",
         "bcrypt": "^5.1.1",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
         "mysql2": "^3.7.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -2492,6 +2494,11 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.11.8",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.8.tgz",
+      "integrity": "sha512-c/hzNDBh7eRF+KbCf+OoZxKbnkpaK/cKp9iLQWqB7muXtM+MtL9SUUH8vCFcLn6dH1Qm05jiexK0ofWY7TfOhQ=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
@@ -3638,6 +3645,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.10.53",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -6723,6 +6745,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.54",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.54.tgz",
+      "integrity": "sha512-P+38dUgJsmh0gzoRDoM4F5jLbyfztkU6PY6eSK6S5HwTi/LPvnwXqVCQZlAy1FxZ5c48q25QhxGQ0pq+WQcSlQ=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -9554,6 +9581,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@types/passport-jwt": "^4.0.0",
     "axios": "^1.6.5",
     "bcrypt": "^5.1.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "mysql2": "^3.7.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/src/entities/userFollows.entity.ts
+++ b/src/entities/userFollows.entity.ts
@@ -1,4 +1,5 @@
 import {
+  Column,
   CreateDateColumn,
   Entity,
   JoinColumn,
@@ -14,6 +15,12 @@ import { UserEntity } from './users.entity';
 export class UserFollowEntity {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @Column({
+    type: 'boolean',
+    default: false,
+  })
+  isFollowingBack: boolean; // 맞팔로우 여부(내가 팔로우 한 유저가 나를 팔로우 했는지)
 
   @CreateDateColumn({
     type: 'timestamp',

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -1,23 +1,3 @@
-// export type LoginResponseDto = {
-//   token: string;
-//   user: UserInfo;
-// };
-
-import { UserEntity } from 'src/entities/users.entity';
-
-// export type UserInfo = {
-//   id: number;
-//   name: string;
-//   email: string;
-//   phoneNumber: string;
-// };
-
-// export type SignUpRequestDto = {
-//   name?: string;
-//   email: string;
-//   password: string;
-// };
-
 export type GetCheckNicknameOverlapDto = {
   nickname?: string;
 };

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -79,7 +79,7 @@ export class UserController {
 
   //  - 팔로잉 목록 : O / 내가 팔로우 한 = 내 id가 userId에 있고, followUserId를 찾아 출력
   @Get('/following')
-  async userFollowingList(
+  async getUserFollowingList(
     @Headers('authorization') token: string,
   ): Promise<UserFollowEntity[] | null> {
     const decodedToken = this.tokenService.verifyToken(token);
@@ -91,7 +91,7 @@ export class UserController {
 
   //  - 팔로워 목록 : O / 나를 팔로우 한 = 내 id가 followUserId에 있고, userId를 찾아 출력
   @Get('/follower')
-  async userFollowerList(
+  async getUserFollowerList(
     @Headers('authorization') token: string,
   ): Promise<UserFollowEntity[] | null> {
     const decodedToken = this.tokenService.verifyToken(token);

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -25,8 +25,11 @@ import {
 } from './dto/user.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { TokenService } from 'src/utils/verifyToken';
+import { UserFollowEntity } from 'src/entities/userFollows.entity';
 
-// 회원가입 상세, 로그아웃, 회원탈퇴, 회원 정보 수정, 닉네임 중복 체크(O), 유저 팔로우(목록, 생성(o), 삭제), 유저 차단(목록, 생성, 삭제)
+// 회원가입 : 회원가입 상세, 로그아웃, 회원탈퇴, 회원 정보 수정, 닉네임 중복 체크(O),
+// 유저 팔로우 : 목록(O), 생성(O), 삭제(O)
+// 유저 차단 : 목록, 생성, 삭제
 
 @Controller('/users')
 export class UserController {
@@ -36,7 +39,7 @@ export class UserController {
     private readonly tokenService: TokenService,
   ) {}
 
-  // 닉네임 중복 체크
+  // 닉네임 중복 체크 : O
   @Get('/check/:nickname')
   async getCheckNicknameOverlap(
     @Param('nickname') nickname: string,
@@ -74,12 +77,29 @@ export class UserController {
     return await this.userService.deleteUserFollow(userFollowDto);
   }
 
-  // 유저 팔로우(목록)_ing
-  @Get('/follow')
-  async userFollowList(
+  //  - 팔로잉 목록 : O / 내가 팔로우 한 = 내 id가 userId에 있고, followUserId를 찾아 출력
+  @Get('/following')
+  async userFollowingList(
     @Headers('authorization') token: string,
-    @Body() body,
-  ): Promise<void> {}
+  ): Promise<UserFollowEntity[] | null> {
+    const decodedToken = this.tokenService.verifyToken(token);
+
+    const userId = decodedToken.aud;
+
+    return await this.userService.followingList(userId);
+  }
+
+  //  - 팔로워 목록 : O / 나를 팔로우 한 = 내 id가 followUserId에 있고, userId를 찾아 출력
+  @Get('/follower')
+  async userFollowerList(
+    @Headers('authorization') token: string,
+  ): Promise<UserFollowEntity[] | null> {
+    const decodedToken = this.tokenService.verifyToken(token);
+
+    const followUserId = decodedToken.aud;
+
+    return await this.userService.followerList(followUserId);
+  }
 
   // 테스트용 로그인 -----------------------------------------------
 
@@ -87,6 +107,7 @@ export class UserController {
   @HttpCode(200)
   async login(@Req() req: Request): Promise<LoginDto> {
     const { socialAccountUid } = req.body;
+
     return await this.userService.login(socialAccountUid);
   }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -88,6 +88,92 @@ export class UserService {
     return await this.userFollowRepository.deleteUserFollow(followRelation);
   }
 
+  // 유저 팔로우(목록)_ing
+  //  - 팔로워 목록 : 나를 팔로우 한
+  async followerList(followUserId: number): Promise<UserFollowEntity[] | null> {
+    const followerList = // 나를 팔로우 한(= userId)
+      await this.userFollowRepository.findFollowerList(followUserId);
+
+    const followingListByCurrentUser = // = 내가 팔로우 한(=followUserId)
+      await this.userFollowRepository.findFollowingList(followUserId);
+
+    // isFollowingBack : 맞팔로우 여부(내가 팔로우 한 유저가 나를 팔로우 했는지)
+    //  - 로그인 한 유저(=나) 기준, 나를 팔로우 한 유저의 목록과 내가 팔로우 한 유저의 목록을 대조 / 서로의 목록에 ID가 있으면 true, 없으면 false
+    //  - followUser, user가 number 혹은 UserEntity 중 어떤 타입인지 확실히 하지 않았다. >> followUser, user를 타입으로 확인하고 일치하도록 구성
+
+    followerList.forEach((follower) => {
+      const followUserId =
+        typeof follower.user === 'number' ? follower.user : follower.user.id;
+
+      follower.isFollowingBack = followingListByCurrentUser.some(
+        (following) => {
+          const followingUserId =
+            typeof following.followUser === 'number'
+              ? following.followUser
+              : following.followUser.id;
+
+          return followUserId === followingUserId;
+        },
+      );
+    });
+
+    return followerList;
+  }
+
+  //  - 팔로잉 목록 : 내가 팔로우 한 = followUserId 출력(내 id가 userId에 있고)
+  async followingList(userId: number): Promise<UserFollowEntity[] | null> {
+    const followingList =
+      await this.userFollowRepository.findFollowingList(userId);
+
+    return followingList;
+  }
+
+  // 원본-------------
+
+  // async followerList(userId: number): Promise<UserFollowEntity[] | null> {
+  //   const followerList =
+  //     await this.userFollowRepository.findFollowerList(userId);
+
+  //   const followingListByCurrentUser =
+  //     await this.userFollowRepository.findFollowingList(userId);
+
+  //   // isFollowingBack : 맞팔로우 여부(나를 팔로우 한 유저를 나도 팔로우 했는지)
+  //   //  - 로그인 한 유저(=나) 기준, 나를 팔로우 한 유저의 목록과 내가 팔로우 한 유저의 목록을 대조해 일치하는 ID가 있으면 true, 없으면 false
+  //   //  - followUser, user가 number 혹은 UserEntity 중 어떤 타입인지 확실히 하지 않았다. >> followUser, user를 타입으로 확인하고 일치하도록 구성
+
+  //   followerList.forEach((follower) => {
+  //     const followUserId =
+  //       typeof follower.followUser === 'number'
+  //         ? follower.followUser
+  //         : follower.followUser.id;
+
+  //     follower.isFollowingBack = followingListByCurrentUser.some(
+  //       (following) => {
+  //         const followingUserId =
+  //           typeof following.user === 'number'
+  //             ? following.user
+  //             : following.user.id;
+
+  //         return followingUserId === followUserId;
+  //       },
+  //     );
+  //   });
+
+  //   return followerList;
+  // }
+
+  // //  - 팔로잉 목록 : 내가 팔로우 한
+  // async followingList(
+  //   followUserId: number,
+  // ): Promise<UserFollowEntity[] | null> {
+  //   const followingList =
+  //     await this.userFollowRepository.findFollowingList(followUserId);
+
+  //   return followingList;
+  // }
+
+  // 원본-------------
+
   // 테스트용 로그인 -----------------------------------------------
 
   async login(socialAccountUid: string): Promise<LoginDto | null> {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -88,9 +88,27 @@ export class UserService {
     return await this.userFollowRepository.deleteUserFollow(followRelation);
   }
 
-  // 유저 팔로우(목록)_ing
-  //  - 팔로워 목록 : 나를 팔로우 한
+  // 유저 팔로우(목록)
+  //  - 팔로잉 목록 : 내가 팔로우 한 = 내 id가 userId에 있고, followUserId를 찾아 출력
+  async followingList(userId: number): Promise<UserFollowEntity[] | null> {
+    if (!userId) throw new NotFoundException('KEY_ERROR');
+
+    const user = this.userRepository.findOneById(userId);
+    if (!user) throw new NotFoundException('USER_NOT_FOUND');
+
+    const followingList =
+      await this.userFollowRepository.findFollowingList(userId);
+
+    return followingList;
+  }
+
+  //  - 팔로워 목록 : 나를 팔로우 한 = 내 id가 followUserId에 있고, userId를 찾아 출력
   async followerList(followUserId: number): Promise<UserFollowEntity[] | null> {
+    if (!followUserId) throw new NotFoundException('KEY_ERROR');
+
+    const followUser = this.userRepository.findOneById(followUserId);
+    if (!followUser) throw new NotFoundException('FOLLOW_USER_NOT_FOUND');
+
     const followerList = // 나를 팔로우 한(= userId)
       await this.userFollowRepository.findFollowerList(followUserId);
 
@@ -119,60 +137,6 @@ export class UserService {
 
     return followerList;
   }
-
-  //  - 팔로잉 목록 : 내가 팔로우 한 = followUserId 출력(내 id가 userId에 있고)
-  async followingList(userId: number): Promise<UserFollowEntity[] | null> {
-    const followingList =
-      await this.userFollowRepository.findFollowingList(userId);
-
-    return followingList;
-  }
-
-  // 원본-------------
-
-  // async followerList(userId: number): Promise<UserFollowEntity[] | null> {
-  //   const followerList =
-  //     await this.userFollowRepository.findFollowerList(userId);
-
-  //   const followingListByCurrentUser =
-  //     await this.userFollowRepository.findFollowingList(userId);
-
-  //   // isFollowingBack : 맞팔로우 여부(나를 팔로우 한 유저를 나도 팔로우 했는지)
-  //   //  - 로그인 한 유저(=나) 기준, 나를 팔로우 한 유저의 목록과 내가 팔로우 한 유저의 목록을 대조해 일치하는 ID가 있으면 true, 없으면 false
-  //   //  - followUser, user가 number 혹은 UserEntity 중 어떤 타입인지 확실히 하지 않았다. >> followUser, user를 타입으로 확인하고 일치하도록 구성
-
-  //   followerList.forEach((follower) => {
-  //     const followUserId =
-  //       typeof follower.followUser === 'number'
-  //         ? follower.followUser
-  //         : follower.followUser.id;
-
-  //     follower.isFollowingBack = followingListByCurrentUser.some(
-  //       (following) => {
-  //         const followingUserId =
-  //           typeof following.user === 'number'
-  //             ? following.user
-  //             : following.user.id;
-
-  //         return followingUserId === followUserId;
-  //       },
-  //     );
-  //   });
-
-  //   return followerList;
-  // }
-
-  // //  - 팔로잉 목록 : 내가 팔로우 한
-  // async followingList(
-  //   followUserId: number,
-  // ): Promise<UserFollowEntity[] | null> {
-  //   const followingList =
-  //     await this.userFollowRepository.findFollowingList(followUserId);
-
-  //   return followingList;
-  // }
-
-  // 원본-------------
 
   // 테스트용 로그인 -----------------------------------------------
 

--- a/src/user/userFollow.repository.ts
+++ b/src/user/userFollow.repository.ts
@@ -9,21 +9,21 @@ import { UserFollowDto } from './dto/user.dto';
 export class UserFollowRepository {
   constructor(
     @InjectRepository(UserFollowEntity)
-    private readonly userFollowRepository: Repository<UserFollowEntity>,
+    private readonly userFollowTypeormRepository: Repository<UserFollowEntity>,
   ) {}
 
   // follow관계 존재 여부 확인(개수)
   async checkFollowOverlap(userFollowDto): Promise<number> {
     const { userId, followUserId } = userFollowDto;
 
-    return await this.userFollowRepository.countBy({
+    return await this.userFollowTypeormRepository.countBy({
       user: { id: userId },
       followUser: { id: followUserId },
     });
   }
 
   async createUserFollow(userFollowDto: UserFollowEntity): Promise<void> {
-    await this.userFollowRepository.save(userFollowDto);
+    await this.userFollowTypeormRepository.save(userFollowDto);
   }
 
   async findFollowRelationByUserIdAndFollowUserId(
@@ -31,7 +31,7 @@ export class UserFollowRepository {
   ): Promise<UserFollowEntity[] | null> {
     const { userId, followUserId } = userFollowDto;
 
-    return await this.userFollowRepository.find({
+    return await this.userFollowTypeormRepository.find({
       select: {
         user: { id: true },
         followUser: { id: true },
@@ -48,6 +48,46 @@ export class UserFollowRepository {
   }
 
   async deleteUserFollow(followRelation: UserFollowEntity[]): Promise<void> {
-    await this.userFollowRepository.remove(followRelation);
+    await this.userFollowTypeormRepository.remove(followRelation);
+  }
+
+  async findFollowingList(userId: number): Promise<UserFollowEntity[] | null> {
+    return this.userFollowTypeormRepository.find({
+      relations: {
+        followUser: true,
+      },
+      select: {
+        id: true,
+        followUser: {
+          id: true,
+          profileImage: true,
+          nickname: true,
+          createdAt: true,
+        },
+      },
+      where: {
+        user: { id: userId },
+      },
+    });
+  }
+
+  async findFollowerList(
+    followUserId: number,
+  ): Promise<UserFollowEntity[] | null> {
+    return this.userFollowTypeormRepository.find({
+      relations: { user: true },
+      select: {
+        id: true,
+        user: {
+          id: true,
+          profileImage: true,
+          nickname: true,
+          createdAt: true,
+        },
+      },
+      where: {
+        followUser: { id: followUserId },
+      },
+    });
   }
 }


### PR DESCRIPTION
## Motivation 🎉
 - 팔로우 리스트를 확인하는 기능 생성 : 팔로잉, 팔로워
 - 인스타그램을 참고하여 기능 추가
   ＊ 기존 : 내가 팔로우 한 유저의 리스트 = 팔로잉 리스트
   ＊ 추가 : 나를 팔로우 한 유저의 리스트 = 팔로워 리스트
 - 팔로워 리스트 : userFollows Entity에 컬럼 추가(isFollowingBack : boolean)
  ＊ 맞팔로우 관계(내가 팔로우 한 유저가 나를 팔로우 했는지)를 boolean값으로 표현


## Key Changes 🗝️
 - api_1 : getUserFollowingList(GET, users/following) : 팔로잉 리스트
 ＊ 에러
   ㆍ user ID가 없을 때
   ㆍ user ID에 해당하는 유저가 없을 때

 - api_2 : getUserFollowerList(GET, users/follower) :  : 팔로워 리스트
 ＊ 에러
   ㆍ followUser ID가 없을 때
   ㆍ followUser ID에 해당하는 유저가 없을 때


DB : userFollows 테이블
![image](https://github.com/team0102/weather-backend/assets/132734576/d0d97072-418b-417f-ad07-0bb0f6a535ca)


![image](https://github.com/team0102/weather-backend/assets/132734576/a375dbb3-907c-4863-8e0e-1d2e22256ffa)


테스트 기준 : 로그인 한 유저의 ID = 42
 - 위 데이터에서 출력 될 데이터 ID
  ＊ api_1(following) : 26, 27, 31
  ＊ api_2(follower) : 14, 17, 28


테스트 : api_1(following) = 26, 27, 31
![image](https://github.com/team0102/weather-backend/assets/132734576/e8cd76af-bdf7-4c3e-b15a-b7e6342e51ef)


테스트 : api_2(follower) = 14, 17, 28
![image](https://github.com/team0102/weather-backend/assets/132734576/9269cf29-4ec4-4dea-9306-0ee9001d7105)

