### PR TITLE
🌈 feat: 피드 수정 api

### DIFF
--- a/src/entities/feedTags.entity.ts
+++ b/src/entities/feedTags.entity.ts
@@ -31,14 +31,14 @@ import { TagEntity } from './tags.entity';
     })
     updatedAt: Date;
     
-    @ManyToOne(() => FeedEntity, { cascade: true})
+    @ManyToOne(() => FeedEntity,)
     @JoinColumn({
       name: 'feedId',
       referencedColumnName: 'id',
     })
     feed: FeedEntity;
 
-    @ManyToOne(() => TagEntity, { cascade: true})
+    @ManyToOne(() => TagEntity,)
     @JoinColumn({
       name: 'tagId',
       referencedColumnName: 'id',

--- a/src/entities/feeds.entity.ts
+++ b/src/entities/feeds.entity.ts
@@ -75,7 +75,7 @@ export class FeedEntity {
   })
   weatherCondition: WeatherConditionEntity;
 
-  @OneToMany(() => FeedImageEntity, (feedImage) => feedImage.feed, { cascade: ['insert'] })
+  @OneToMany(() => FeedImageEntity, (feedImage) => feedImage.feed, { cascade: ['insert', 'update']})
   feedImage: FeedImageEntity[];
 
   @OneToMany(() => FeedCommentEntity, (feedComment) => feedComment.feed)
@@ -84,7 +84,7 @@ export class FeedEntity {
   @OneToMany(() => FeedLikeEntity, (feedLike) => feedLike.feed)
   feedLike: FeedLikeEntity[];
 
-  @OneToMany(() => FeedTagEntity, (feedTag) => feedTag.feed, { cascade: ['insert'] })
+  @OneToMany(() => FeedTagEntity, (feedTag) => feedTag.feed, { cascade: ['insert', 'update', 'remove']})
   feedTag: FeedTagEntity[];
 
   @OneToMany(() => BookmarkEntity, (bookmark) => bookmark.feed)

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -6,7 +6,6 @@ import {
   ParseIntPipe,
   Post,
   Headers,
-  Query,
   Put,
   Delete,
 } from '@nestjs/common';
@@ -19,8 +18,6 @@ import {
   FeedDetailResponse,
   FeedListResponse,
 } from './feed.types';
-import { TransformationType } from 'class-transformer';
-import { errorMonitor } from 'stream';
 
 @Controller('feeds')
 export class FeedController {
@@ -92,30 +89,38 @@ export class FeedController {
     @Headers('Authorization') token: string,
     @Param('feedId', ParseIntPipe) feedId: number,
   ): Promise<ApiResponse> {
-   try{
-    const loginUserId = this.tokenService.audienceFromToken(token);
-    await this.feedService.deleteFeed(loginUserId, feedId);
-    return {statusCode: 200, message: 'Feed deledted successfully'}
-   }catch(error) {
-    console.log(errorMonitor)
-    return { statusCode: error.code || 500, message: error.message };
-   }
+    try {
+      const loginUserId = this.tokenService.audienceFromToken(token);
+      await this.feedService.deleteFeed(loginUserId, feedId);
+      return { statusCode: 200, message: 'Feed deledted successfully' };
+    } catch (error) {
+      console.log(error);
+      return { statusCode: error.code || 500, message: error.message };
+    }
   }
 
-  // @Put(/:feedId)
-  // async updateFeed(
-  //   @Headers('Authorization') token: string,
-  //   @Body() feedData: UpdateFeedDTO,
-  // ) {
-  //   try{
-  //     const loginUserId = this.tokenService.audienceFromToken(token);
-  //     await this.feedService.updateFeed(loginUserId, feedData);
-  //     return { statusCode: 201, message: 'Feed created successfully' };
-  //   } catch(error) {
-  //     console.log(error)
-  //     return { statusCode: error.code || 500, message: error.message };
-  //   }
-  // }
+  @Put('/:feedId')
+  async updateFeed(
+    @Headers('Authorization') token: string,
+    @Param('feedId') feedId: number,
+    @Body() feedData: UpdateFeedDTO,
+  ): Promise<ApiResponse> {
+    try {
+      const loginUserId = this.tokenService.audienceFromToken(token);
+      const updatedFeed = await this.feedService.updateFeed(
+        loginUserId,
+        feedId,
+        feedData,
+      );
+      return {
+        statusCode: 201,
+        message: 'Feed updated successfully',
+      };
+    } catch (error) {
+      console.log(error);
+      return { statusCode: error.code || 500, message: error.message };
+    }
+  }
 
   @Post('/:feedId/comment')
   async createComment(

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -126,7 +126,7 @@ export class FeedController {
   async createComment(
     @Headers('Authorization') token: string,
     @Param('feedId', ParseIntPipe) feedId: number,
-    @Body() content: string,
+    @Body('content') content: string,
   ): Promise<ApiResponse> {
     try {
       const loginUserId = this.tokenService.audienceFromToken(token);

--- a/src/feed/feed.repository.ts
+++ b/src/feed/feed.repository.ts
@@ -81,7 +81,7 @@ export class FeedRepository {
         feed: savedFeed,
         imageUrl: imageUrl,
       });
-      console.log('createFeed savedFeed : ', savedFeed, savedFeedImage);
+      //console.log('createFeed savedFeed : ', savedFeed, savedFeedImage);
       return savedFeed;
     } catch (error) {
       console.log(error);
@@ -103,55 +103,38 @@ export class FeedRepository {
   }
 
   //=======================================update feed =============================
-  // async updateFeed(userId: number, feedData: UpdateFeedDTO, newDate: Date) {
-  //   try {
-  //     const {
-  //       weatherConditionId,
-  //       highTemperature,
-  //       lowTemperature,
-  //       content,
-  //       image,
-  //     } = feedData;
-
-  //     //피드 저장 및 연결
-  //     const savedFeed = await this.feedRepository.save({
-  //       user: { id: userId },
-  //       weatherCondition: { id: weatherConditionId },
-  //       highTemperature,
-  //       lowTemperature,
-  //       content,
-  //       createdAt: newDate,
-  //       updatedAt: newDate,
-  //     });
-
-  //     // 이미지 저장 및 연결
-  //     const savedFeedImage = await this.feedImageRepository.save({
-  //       imageUrl: image,
-  //       createdAt: newDate,
-  //       updatedAt: newDate,
-  //       feed: { id: savedFeed.id },
-  //     });
-
-  //     // 결과 반환
-  //     const result = {
-  //       feed: savedFeed,
-  //       feedImage: savedFeedImage,
-  //     };
-  //     console.log('createFeed result : ', result);
-  //     return result;
-  //   } catch (error) {
-  //     console.log(error.message);
-  //     throw new Error(error.message);
-  //   }
-  // }
+  async updateFeed(feedId: number, feedData: UpdateFeedDTO) {
+    const { weatherConditionId, imageUrl, ...updateData } = feedData;
+    try {
+      if (weatherConditionId) {
+        await this.feedRepository.update(
+          { id: feedId },
+          { weatherCondition: { id: weatherConditionId }},
+        );
+      }
+      const updateFeed = await this.feedRepository.update(
+        { id: feedId },
+        { ...updateData },
+      );
+      const updateFeedImage = await this.feedImageRepository.update(
+        { feed: { id: feedId } },
+        { imageUrl: imageUrl },
+      );
+      //console.log('updateFeed savedFeed : ', updateFeed, updateFeedImage);
+      return updateFeed;
+    } catch (error) {
+      console.log(error);
+      throw new Error(error.message);
+    }
+  }
 
   async findFeedById(feedId: number): Promise<FeedEntity> {
     try {
       const result = await this.feedRepository.findOne({
         where: { id: feedId },
-        relations: ['user',]
+        relations: ['user', 'feedTag'],
       });
-      console.log('repo result : ', result)
+      console.log('repo result : ', result);
       return result;
     } catch (error) {
       console.log(error);

--- a/src/feed/feed.types.ts
+++ b/src/feed/feed.types.ts
@@ -33,7 +33,7 @@ export type FeedListItem = {
 export type FeedDetailResponse = {
   statusCode: number;
   message: string;
-  data?: FeedListItem;
+  data?: FeedDatail;
 };
 
 export type FeedDatail = {

--- a/src/feed/feedTag.repository.ts
+++ b/src/feed/feedTag.repository.ts
@@ -1,9 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { FeedTagEntity } from 'src/entities/feedTags.entity';
-import { FeedEntity } from 'src/entities/feeds.entity';
-import { TagEntity } from 'src/entities/tags.entity';
-import { Repository, QueryRunner } from 'typeorm';
+import { Repository, QueryRunner, In } from 'typeorm';
 
 @Injectable()
 export class FeedTagRepository {
@@ -23,14 +21,30 @@ export class FeedTagRepository {
         tagIds.map(async (tagId) => {
           return this.feedTagRepository.save({
             feed: { id: feedId },
-            tag: { id: tagId},
-          })
+            tag: { id: tagId },
+          });
         }),
       );
       await queryRunner.commitTransaction();
-      console.log('createFeedTag result : ', savedFeedTags);
       return savedFeedTags;
     } catch (error) {
+      console.log(error);
+      throw new Error(error.message);
+    }
+  }
+
+  async deletedFeedTags(
+    feedTagsIds: number[],
+    queryRunner: QueryRunner,
+  ): Promise<void> {
+    try {
+      await queryRunner.startTransaction();
+      for (const feedTagId of feedTagsIds) {
+        await this.feedTagRepository.delete(feedTagId);
+      }
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
       console.log(error);
       throw new Error(error.message);
     }

--- a/src/feed/tag.repository.ts
+++ b/src/feed/tag.repository.ts
@@ -10,7 +10,7 @@ export class TagRepository {
     private readonly tagRepository: Repository<TagEntity>,
   ) {}
 
-  async createTag(tag: string) {
+  async createTag(tag: string):Promise<TagEntity> {
     try {
       const savedTag = await this.tagRepository.save({
         content: tag,
@@ -23,7 +23,7 @@ export class TagRepository {
     }
   }
 
-  async findTagByContent(tag: string) {
+  async findTagByContent(tag: string):Promise<TagEntity> {
     try {
       const foundTag = await this.tagRepository.findOne({
         where: { content: tag },


### PR DESCRIPTION
## Motivation 🎉
 - 피드 수정 API 추가 :    PUT /feeds/:feedId
   ＊ 피드 작성 시 필요한 데이터와 동일
＊ 유저는 이미지와 컨텐츠를 변경할 수 있음

 - 댓글 작성 API 수정 
 ＊ 댓글 작성 시 content 추출 부분 수정 : @Body('contetnt') 


![image](https://github.com/team0102/weather-backend/assets/120547603/5b9522fc-3e5e-4dde-9942-4e264203bf20)

   
![image](https://github.com/team0102/weather-backend/assets/120547603/6a228149-972a-41ff-aef6-18a972bf1ea0)



## Key Changes 🗝️
 - 이미지와 컨텐츠 업데이트
 -  에러핸들링
   ＊ 존재하는 feedId만 수정 가능
＊ 삭제되지 않은 feed만 수정 가능
＊ 작성자만 수정 가능

 - 수정된 컨텐츠의 tag가 기존 feed에 존재하는 지 여부 확인
   ＊  존재했지만 삭제된 tag에 해당하는 feedTag삭제, tag테이블에서는 유지
＊ 존재하지 않은 새로 추가된 tag라면 tag테이블과 feedTag에 새로 생성 

