### PR TITLE
좋아요 API 생성 및 CatchException, HttpError 생성 및 적용

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { typeORMConfig } from './config/typeORM.config';
 import { ConfigModule } from '@nestjs/config';
@@ -9,6 +10,7 @@ import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
 import { FeedModule } from './feed/feed.module';
 import { ClothesModule } from './clothes/clothes.module';
+import CatchException from './utils/CatchException';
 
 @Module({
   imports: [
@@ -27,5 +29,9 @@ import { ClothesModule } from './clothes/clothes.module';
     FeedModule,
     ClothesModule,
   ],
+  providers: [{
+    provide: APP_FILTER,
+    useClass: CatchException,
+  }]
 })
 export class AppModule {}

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -8,9 +8,6 @@ import {
   Headers,
   Put,
   Delete,
-  HttpException,
-  HttpStatus,
-  UseFilters,
 } from '@nestjs/common';
 import { FeedService } from './feed.service';
 import { CreateFeedDTO } from './dto/create-feed.dto';
@@ -42,13 +39,13 @@ export class FeedController {
       }
       const feedDatas = await this.feedService.getFeedList(loginUserId);
       return {
-        statusCode: 200,
+        status: 200,
         message: 'Successed to get feedList',
         data: feedDatas,
       };
     } catch (error) {
       console.log(error);
-      return { statusCode: error.code || 500, message: error.message };
+      return { status: error.code || 500, message: error.message };
     }
   }
 
@@ -60,13 +57,13 @@ export class FeedController {
       const loginUserId = this.tokenService.audienceFromToken(token);
       const bookmarkList = await this.feedService.getBookmarkList(loginUserId);
       return {
-        statusCode: 201,
+        status: 201,
         message: 'Successed to get BookmarkList',
         data: bookmarkList,
       };
     } catch (error) {
       console.log(error);
-      return { statusCode: error.code || 500, message: error.message };
+      return { status: error.code || 500, message: error.message };
     }
   }
 
@@ -82,13 +79,13 @@ export class FeedController {
         feedId,
       );
       return {
-        statusCode: 200,
+        status: 200,
         message: 'Successed to get feedDetails',
         data: feedData,
       };
     } catch (error) {
       console.log(error);
-      return { statusCode: error.code || 500, message: error.message };
+      return { status: error.code || 500, message: error.message };
     }
   }
 
@@ -100,10 +97,10 @@ export class FeedController {
     try {
       const loginUserId = this.tokenService.audienceFromToken(token);
       await this.feedService.createFeed(loginUserId, feedData);
-      return { statusCode: 201, message: 'Feed created successfully' };
+      return { status: 201, message: 'Feed created successfully' };
     } catch (error) {
       console.log(error);
-      return { statusCode: error.code || 500, message: error.message };
+      return { status: error.code || 500, message: error.message };
     }
   }
 
@@ -115,10 +112,10 @@ export class FeedController {
     try {
       const loginUserId = this.tokenService.audienceFromToken(token);
       await this.feedService.deleteFeed(loginUserId, feedId);
-      return { statusCode: 200, message: 'Feed deledted successfully' };
+      return { status: 200, message: 'Feed deledted successfully' };
     } catch (error) {
       console.log(error);
-      return { statusCode: error.code || 500, message: error.message };
+      return { status: error.code || 500, message: error.message };
     }
   }
 
@@ -136,12 +133,12 @@ export class FeedController {
         feedData,
       );
       return {
-        statusCode: 201,
+        status: 201,
         message: 'Feed updated successfully',
       };
     } catch (error) {
       console.log(error);
-      return { statusCode: error.code || 500, message: error.message };
+      return { status: error.code || 500, message: error.message };
     }
   }
 
@@ -154,10 +151,10 @@ export class FeedController {
     try {
       const loginUserId = this.tokenService.audienceFromToken(token);
       await this.feedService.createComment(loginUserId, feedId, content);
-      return { statusCode: 201, message: 'Comment created successfully' };
+      return { status: 201, message: 'Comment created successfully' };
     } catch (error) {
       console.log(error);
-      return { statusCode: error.code || 500, message: error.message };
+      return { status: error.code || 500, message: error.message };
     }
   }
 
@@ -169,10 +166,10 @@ export class FeedController {
     try {
       const loginUserId = this.tokenService.audienceFromToken(token);
       await this.feedService.createBookmark(loginUserId, feedId);
-      return { statusCode: 201, message: 'Bookmark created successfully' };
+      return { status: 201, message: 'Bookmark created successfully' };
     } catch (error) {
       console.log(error);
-      return { statusCode: error.code || 500, message: error.message };
+      return { status: error.code || 500, message: error.message };
     }
   }
 
@@ -188,6 +185,6 @@ export class FeedController {
     }
     const loginUserId = this.tokenService.audienceFromToken(token);
     await this.feedService.handleFeedLike(isLiked, loginUserId, feedId);
-    return { statusCode: 201, message: 'FeedLike changed successfully' };
+    return { status: 201, message: 'FeedLike changed successfully' };
   }
 }

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -171,4 +171,22 @@ export class FeedController {
       return { statusCode: error.code || 500, message: error.message };
     }
   }
+
+  @Post('/:feedId/like')
+  async handleFeedLike(
+    @Headers('Authorization') token: string,
+    @Param('feedId', ParseIntPipe) feedId: number,
+    @Body('isLiked') isLiked: unknown,
+  ): Promise<ApiResponse> {
+    try {
+      //isLiked가 boolean이 아니거나 빈 값이라면 에러 발생
+      if (typeof isLiked !== 'boolean') throw new Error('Invalid value for isLiked');
+      const loginUserId = this.tokenService.audienceFromToken(token);
+      await this.feedService.handleFeedLike(isLiked, loginUserId, feedId);
+      return { statusCode: 201, message: 'FeedLike changed successfully' };
+    } catch (error) {
+      console.log(error);
+      return { statusCode: error.code || 500, message: error.message };
+    }
+  }
 }

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -8,6 +8,9 @@ import {
   Headers,
   Put,
   Delete,
+  HttpException,
+  HttpStatus,
+  UseFilters,
 } from '@nestjs/common';
 import { FeedService } from './feed.service';
 import { CreateFeedDTO } from './dto/create-feed.dto';
@@ -19,6 +22,7 @@ import {
   FeedDetailResponse,
   FeedListResponse,
 } from './feed.types';
+import HttpError from 'src/utils/httpError';
 
 @Controller('feeds')
 export class FeedController {
@@ -178,15 +182,12 @@ export class FeedController {
     @Param('feedId', ParseIntPipe) feedId: number,
     @Body('isLiked') isLiked: unknown,
   ): Promise<ApiResponse> {
-    try {
+    if (typeof isLiked !== 'boolean') {
       //isLiked가 boolean이 아니거나 빈 값이라면 에러 발생
-      if (typeof isLiked !== 'boolean') throw new Error('Invalid value for isLiked');
-      const loginUserId = this.tokenService.audienceFromToken(token);
-      await this.feedService.handleFeedLike(isLiked, loginUserId, feedId);
-      return { statusCode: 201, message: 'FeedLike changed successfully' };
-    } catch (error) {
-      console.log(error);
-      return { statusCode: error.code || 500, message: error.message };
+      throw new HttpError(400, 'Invalid value for isLiked');
     }
+    const loginUserId = this.tokenService.audienceFromToken(token);
+    await this.feedService.handleFeedLike(isLiked, loginUserId, feedId);
+    return { statusCode: 201, message: 'FeedLike changed successfully' };
   }
 }

--- a/src/feed/feed.module.ts
+++ b/src/feed/feed.module.ts
@@ -15,6 +15,7 @@ import { FeedCommentRepository } from './feedComment.repository';
 import { TokenService } from 'src/utils/verifyToken';
 import { BookmarkEntity } from 'src/entities/bookmarks.entity';
 import { BookmarkRepository } from './bookmark.repository';
+import { FeedLikeRepository } from './feedLike.repository';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { BookmarkRepository } from './bookmark.repository';
     TagRepository,
     FeedTagRepository,
     FeedCommentRepository,
+    FeedLikeRepository,
     BookmarkRepository,
   ],
   exports: [TypeOrmModule],

--- a/src/feed/feed.repository.ts
+++ b/src/feed/feed.repository.ts
@@ -73,6 +73,7 @@ export class FeedRepository {
           },
         },
       });
+      console.log(feed);
       return feed;
   }
 

--- a/src/feed/feed.repository.ts
+++ b/src/feed/feed.repository.ts
@@ -48,7 +48,6 @@ export class FeedRepository {
   }
 
   async getFeedWithDetailsById(feedId: number): Promise<FeedEntity> {
-    try {
       const [feed] = await this.feedRepository.find({
         relations: {
           user: true,
@@ -75,10 +74,6 @@ export class FeedRepository {
         },
       });
       return feed;
-    } catch (error) {
-      console.log(error);
-      throw new Error(error.message);
-    }
   }
 
   async createFeed(

--- a/src/feed/feed.repository.ts
+++ b/src/feed/feed.repository.ts
@@ -56,7 +56,9 @@ export class FeedRepository {
           feedComment: {
             user: true,
           },
-          feedLike: true,
+          feedLike: {
+            user: true,
+          },
           weatherCondition: true,
           bookmark: {
             user: true,

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -241,13 +241,21 @@ export class FeedService {
       if (!findFeed.user || findFeed.user.id !== loginUserId)
         throw new Error('Invalid User');
 
-      // feedTag는 delete
+      // feedTag들 delete
       if (findFeed.feedTag) {
         findFeed.feedTag.forEach(async (feedTag) => {
           const deleteFeedTagIds: number[] = [];
           deleteFeedTagIds.push(feedTag.id);
           await this.feedTagRepository.deleteFeedTags(deleteFeedTagIds);
         });
+      }
+      //feedLike들 delete
+      if(findFeed.feedLike) {
+        findFeed.feedLike.forEach(async (feedLike) => {
+          const deledtedFeedLikeIds: number[] = [];
+          deledtedFeedLikeIds.push(feedLike.id);
+          await this.feedLikeRepository.deleteFeedLikesByIds(deledtedFeedLikeIds);
+        })
       }
       // bookmark는 delete
       // if (findFeed.bookmark) {
@@ -256,6 +264,7 @@ export class FeedService {
       //     await this.bookmarkRepository.deleteBookmark(bookmark);
       //   });
       // };
+
       // feedComment는 softDelete
       // if (findFeed.feedComment) {
       //   findFeed.feedComment.forEach(async (comment) => {

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -42,7 +42,7 @@ export class FeedService {
               (like) => like.user.id === userId,
             );
             const isBookmarked = feed.bookmark.some(
-              (bookmark) => bookmark.user.id === userId,
+              (bookmark) => bookmark.user !==null && bookmark.user.id === userId,
             );
             const { id, nickname, profileImage } = feed.user;
             const imageUrl =
@@ -83,7 +83,7 @@ export class FeedService {
     try {
       const feedDetails =
         await this.feedRepository.getFeedWithDetailsById(feedId);
-      if (!feedDetails || feedDetails.deletedAt)
+      if (!feedDetails || feedDetails.deletedAt || !feedDetails.user)
         throw new Error('Feed does not exist');
       const isAuthor = feedDetails.user.id === userId;
       const likeCount = feedDetails.feedLike.length;
@@ -92,7 +92,7 @@ export class FeedService {
         (like) => like.user.id === userId,
       );
       const isBookmarked = feedDetails.bookmark.some(
-        (bookmark) => bookmark.user.id === userId,
+        (bookmark) => bookmark.user !==null && bookmark.user.id === userId,
       );
       const { id, nickname, profileImage } = feedDetails.user;
       const imageUrl =

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -372,7 +372,7 @@ export class FeedService {
   async handleFeedLike(isLiked: boolean, loginUserId: number, feedId: number) {
     // 존재하는 피드인지, 삭제되지 않은 피드인지, 작성자가 탈퇴하지 않았는지 에러 핸들링
     const findFeed = await this.feedRepository.getFeedWithDetailsById(feedId);
-    if (!findFeed || findFeed.deletedAt || findFeed.user.deletedAt)
+    if (!findFeed || findFeed.deletedAt || !findFeed.user)
       throw new HttpError(404, 'Feed does not exist');
 
     // 좋아요를 누르지 않은 상태(isLike = false)에서 요청이 오면 좋아요 생성

--- a/src/feed/feed.types.ts
+++ b/src/feed/feed.types.ts
@@ -1,10 +1,10 @@
 export type ApiResponse = {
-  statusCode: number;
+  status: number;
   message: string;
 };
 
 export type FeedListResponse = {
-  statusCode: number;
+  status: number;
   message: string;
   data?: FeedListItem[];
 };
@@ -31,7 +31,7 @@ export type FeedListItem = {
 };
 
 export type FeedDetailResponse = {
-  statusCode: number;
+  status: number;
   message: string;
   data?: FeedDatail;
 };
@@ -69,7 +69,7 @@ export type FeedDatail = {
 };
 
 export type BookmarkListResponse = {
-  statusCode: number;
+  status: number;
   message: string;
   data?: BookmarkList[];
 };

--- a/src/feed/feedLike.repository.ts
+++ b/src/feed/feedLike.repository.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FeedLikeEntity } from 'src/entities/feedLikes.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class FeedLikeRepository {
+  constructor(
+    @InjectRepository(FeedLikeEntity)
+    private readonly feedLikeRepository: Repository<FeedLikeEntity>,
+  ) {}
+
+  async findFeedLikeByFeedIdAndUserId(
+    loginUserId: number,
+    feedId: number,
+  ): Promise<FeedLikeEntity> {
+    try {
+      console.log(loginUserId, feedId);
+      const result = await this.feedLikeRepository.findOne({
+        where: {
+          user: { id: loginUserId },
+          feed: { id: feedId },
+        },
+      });
+      console.log(result);
+      return result;
+    } catch (error) {
+      console.log(error);
+      throw new Error(error.message);
+    }
+  }
+
+  async createFeedLike(loginUserId: number, feedId: number): Promise<void> {
+    try {
+      const result = await this.feedLikeRepository.save({
+        user: { id: loginUserId },
+        feed: { id: feedId },
+      });
+    } catch (error) {
+      console.log(error);
+      throw new Error(error.message);
+    }
+  }
+
+  async deleteFeedLike(id: number): Promise<void> {
+    try {
+      await this.feedLikeRepository.delete({ id });
+    } catch (error) {
+      console.log(error);
+      throw new Error(error.message);
+    }
+  }
+}

--- a/src/feed/feedLike.repository.ts
+++ b/src/feed/feedLike.repository.ts
@@ -14,49 +14,29 @@ export class FeedLikeRepository {
     loginUserId: number,
     feedId: number,
   ): Promise<FeedLikeEntity> {
-    try {
-      console.log(loginUserId, feedId);
-      const result = await this.feedLikeRepository.findOne({
-        where: {
-          user: { id: loginUserId },
-          feed: { id: feedId },
-        },
-      });
-      console.log(result);
-      return result;
-    } catch (error) {
-      console.log(error);
-      throw new Error(error.message);
-    }
+    console.log(loginUserId, feedId);
+    const result = await this.feedLikeRepository.findOne({
+      where: {
+        user: { id: loginUserId },
+        feed: { id: feedId },
+      },
+    });
+    console.log(result);
+    return result;
   }
 
   async createFeedLike(loginUserId: number, feedId: number): Promise<void> {
-    try {
-      const result = await this.feedLikeRepository.save({
-        user: { id: loginUserId },
-        feed: { id: feedId },
-      });
-    } catch (error) {
-      console.log(error);
-      throw new Error(error.message);
-    }
+    await this.feedLikeRepository.save({
+      user: { id: loginUserId },
+      feed: { id: feedId },
+    });
   }
 
   async deleteFeedLike(id: number): Promise<void> {
-    try {
-      await this.feedLikeRepository.delete({ id });
-    } catch (error) {
-      console.log(error);
-      throw new Error(error.message);
-    }
+    await this.feedLikeRepository.delete({ id });
   }
 
   async deleteFeedLikesByIds(ids: number[]): Promise<void> {
-    try {
-      await this.feedLikeRepository.delete(ids);
-    } catch (error) {
-      console.log(error);
-      throw new Error(error.message);
-    }
+    await this.feedLikeRepository.delete(ids);
   }
 }

--- a/src/feed/feedLike.repository.ts
+++ b/src/feed/feedLike.repository.ts
@@ -50,4 +50,13 @@ export class FeedLikeRepository {
       throw new Error(error.message);
     }
   }
+
+  async deleteFeedLikesByIds(ids: number[]): Promise<void> {
+    try {
+      await this.feedLikeRepository.delete(ids);
+    } catch (error) {
+      console.log(error);
+      throw new Error(error.message);
+    }
+  }
 }

--- a/src/utils/CatchException.ts
+++ b/src/utils/CatchException.ts
@@ -1,0 +1,32 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from "@nestjs/common";
+import { HttpArgumentsHost } from "@nestjs/common/interfaces";
+
+@Catch()
+export default class CatchException implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx: HttpArgumentsHost = host.switchToHttp();
+    const response = ctx.getResponse();
+
+    let httpError = null;
+    console.log(exception);
+
+    if (exception instanceof HttpException) {
+      httpError = {
+        status: exception.getStatus(), // throw new HttpError()로 던진 첫번째 매개변수 status 값
+        message: exception.message, // throw new HttpError()로 던진 두번째 매개변수 message 값
+      };
+    } 
+    else {
+      httpError = {
+        status: 500,
+        message: 'INTERNAL_SERVER_ERROR',
+      };
+    }
+    const { status, message } = httpError;
+    // 클라이언트 응답 (위 조건분기에 따른 객체의 값들)
+    return response.status(status).json({
+      status,
+      message,
+    });
+  }
+}

--- a/src/utils/httpError.ts
+++ b/src/utils/httpError.ts
@@ -1,0 +1,12 @@
+import { HttpException } from "@nestjs/common";
+
+export default class HttpError extends HttpException {
+  public statusCode: number = 0;
+  public message: string = '';
+
+  constructor(status: number, message: string) {
+    super(message, status);
+    this.statusCode = status;
+    this.message = message;
+  }
+}


### PR DESCRIPTION
## Motivation 🎉
 - 좋아요 API 생성 POST feeds/:feedId/like
 - feed 삭제 시 해당 feedLike 삭제
![image](https://github.com/team0102/weather-backend/assets/120547603/298feb98-3150-4cde-9ec6-db62cde2b515)

 -  예외 처리를 간편화하고자 utils 내 CatchException, HttpError  생성


## Key Changes 🗝️
 - 좋아요를 누른 상태에서 요청이 오면 좋아요 취소, 좋아요를 누르지 않은 상태에서 요청이 오면 좋아요 생성
   ＊ isLiked :  유저가 이미 해당 피드의 좋아요를 누른 상태인지 (ture/false)
![image](https://github.com/team0102/weather-backend/assets/120547603/bf6c858e-7ac9-46ae-829a-c483cdad2462)
![image](https://github.com/team0102/weather-backend/assets/120547603/03c497a4-e15a-4f91-9fd1-527d34f1ba3f)

 - 좋아요 API 에러 핸들링
 ＊body의 isLiked가 존재하지 않거나 boolean값이 아닌 경우
   ＊ 존재하지 않은 피드의 경우
＊ 삭제한 피드의 경우
＊ 피드의 작성자가 탈퇴한 경우
＊ 좋아요 생성 요청이 왔는데 이미 feedLike가 존재하거나, 좋아요 삭제 요청이 왔는데 해당 feedLike가 존재하지 않은 경우
 -  HttpError로써 throw new HttpError(404, 'Feed does not exist'); 와 같이 작성 가능
 
![image](https://github.com/team0102/weather-backend/assets/120547603/dbe23826-0662-4f23-b73f-4339d6ff968e)

 -  CatchException로써 try-catch 를 생략하고 클라이언트에게 예외처리된 에러 status와 message 응답 
 ＊ app.module 내 providers에 필터로 추가
![image](https://github.com/team0102/weather-backend/assets/120547603/1a62dbed-1e91-4744-bf31-839ab83f1871)

 -  repo 변경에 따른 오류 수정 : 탈퇴한 회원 
 -  응답값 키 변경 : statusCode -> status

 ## Check
  - bookmark 관련 로직 수정 예정
