### PR TITLE
createBookmark 에서 handleBookmark로 api 수정

### DIFF
--- a/src/feed/bookmark.repository.ts
+++ b/src/feed/bookmark.repository.ts
@@ -11,7 +11,6 @@ export class BookmarkRepository {
   ) {}
 
   async isBookmarked(userId: number, feedId: number): Promise<BookmarkEntity> {
-    try {
       const findBookmark = await this.bookmarkRepository.findOne({
         where: {
           user: { id: userId },
@@ -19,30 +18,25 @@ export class BookmarkRepository {
         },
       });
       return findBookmark;
-    } catch (error) {
-      console.log(error);
-      throw new Error(error.message);
-    }
   }
 
   async createBookmark(
     userId: number,
     feedId: number,
   ): Promise<BookmarkEntity> {
-    try {
       const result = await this.bookmarkRepository.save({
         user: { id: userId },
         feed: { id: feedId },
       });
       return result;
-    } catch (error) {
-      console.log(error);
-      throw new Error(error.message);
-    }
-  }
+  };
 
-  async getBookmarkList(userId: number):Promise<BookmarkEntity[]> {
-    try {
+  async deleteBookmark(id: number): Promise<void> {
+      const result = await this.bookmarkRepository.delete({ id });
+      //console.log(result)
+  };
+
+  async getBookmarkList(userId: number): Promise<BookmarkEntity[]> {
       const result = await this.bookmarkRepository.find({
         relations: {
           feed: {
@@ -57,7 +51,7 @@ export class BookmarkRepository {
             deletedAt: null,
             user: {
               deletedAt: null,
-            }
+            },
           },
           user: {
             id: userId,
@@ -65,9 +59,5 @@ export class BookmarkRepository {
         },
       });
       return result;
-    } catch (error) {
-      console.log(error);
-      throw new Error(error.message);
-    }
   }
 }

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -53,7 +53,6 @@ export class FeedController {
   async getBookmarkList(
     @Headers('Authorization') token: string,
   ): Promise<BookmarkListResponse> {
-    try {
       const loginUserId = this.tokenService.audienceFromToken(token);
       const bookmarkList = await this.feedService.getBookmarkList(loginUserId);
       return {
@@ -61,10 +60,6 @@ export class FeedController {
         message: 'Successed to get BookmarkList',
         data: bookmarkList,
       };
-    } catch (error) {
-      console.log(error);
-      return { status: error.code || 500, message: error.message };
-    }
   }
 
   @Get('/:feedId')
@@ -159,19 +154,31 @@ export class FeedController {
   }
 
   @Post('/:feedId/bookmark')
-  async createBookmark(
+  async handleBookmark(
     @Headers('Authorization') token: string,
     @Param('feedId', ParseIntPipe) feedId: number,
+    @Body('isBookmarked') isBookmarked: unknown,
   ): Promise<ApiResponse> {
-    try {
+      if(typeof isBookmarked !== 'boolean'){
+        //isBookmarked boolean이 아니거나 빈 값이라면 에러 발생
+      throw new HttpError(400, 'Invalid value for isBookmarked');
+      }
       const loginUserId = this.tokenService.audienceFromToken(token);
-      await this.feedService.createBookmark(loginUserId, feedId);
-      return { status: 201, message: 'Bookmark created successfully' };
-    } catch (error) {
-      console.log(error);
-      return { status: error.code || 500, message: error.message };
-    }
+      await this.feedService.handleBookmark(loginUserId, feedId, isBookmarked);
+      return { status: 201, message: 'Bookmark changed successfully' };
   }
+
+
+  // 기존 북마크 추가 요청
+  // @Post('/:feedId/bookmark')
+  // async createBookmark(
+  //   @Headers('Authorization') token: string,
+  //   @Param('feedId', ParseIntPipe) feedId: number,
+  // ): Promise<ApiResponse> {
+  //     const loginUserId = this.tokenService.audienceFromToken(token);
+  //     await this.feedService.createBookmark(loginUserId, feedId;
+  //     return { status: 201, message: 'Bookmark created successfully' };
+  // }
 
   @Post('/:feedId/like')
   async handleFeedLike(


### PR DESCRIPTION
## Motivation 🎉
 - bookmark API 수정 
   ＊ 기존 createBookmark 에서 handleBookmark로 수정
 - HttpErro 적용, try-catch 삭제
  
![image](https://github.com/team0102/weather-backend/assets/120547603/881b6467-28b0-4a90-b721-6a76318b66d6)
![image](https://github.com/team0102/weather-backend/assets/120547603/ed4c9fb9-c5b2-454f-a51b-d086768ce43f)


## Key Changes 🗝️
 - 피드에서 북마크 아이콘을 누를 때 클라이언트에게 isBookmark(true/false)를 받아 북마크를 추가하거나 삭제
   ＊기존 createBookmark api 유지, 프론트와 협의하여 활용 예정
![image](https://github.com/team0102/weather-backend/assets/120547603/14cc3ba6-c8ec-4ed4-a901-e9e1135d04fe)
![image](https://github.com/team0102/weather-backend/assets/120547603/4e3627b7-7907-4d2a-a9f8-38c820cb9bd1)


- 에러 핸들링
＊body의 isBookmark가 존재하지 않거나 boolean값이 아닌 경우
＊ 존재하지 않은 피드의 경우
＊ 삭제한 피드의 경우
＊ 피드의 작성자가 탈퇴한 경우
＊ 북마크 추가 요청이 왔는데 이미 bookmark가 존재하거나, 북마크 취소 요청이 왔는데 해당 bookmark가 존재하지 않은 경우

 
  

## Check 📝
- 북마크 리스트에서 삭제 시 활용하도록 deleteBookmark 생성 예정