### PR TITLE
댓글 삭제 API

### DIFF
--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -120,6 +120,17 @@ export class FeedController {
     return { status: 201, message: 'Comment created successfully' };
   }
 
+  @Delete('/:feedId/comment/:commentId')
+  async deleteComment(
+    @Headers('Authorization') token: string,
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @Param('feedId', ParseIntPipe) feedId: number,
+  ): Promise<ApiResponse> {
+    const loginUserId = this.tokenService.audienceFromToken(token);
+    await this.feedService.deleteComment(loginUserId, feedId, commentId);
+    return { status: 204, message: 'Comment deleted successfully' };
+  }
+
   @Post('/like/:feedId')
   async handleFeedLike(
     @Headers('Authorization') token: string,

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -88,7 +88,7 @@ export class FeedController {
   ): Promise<ApiResponse> {
     const loginUserId = this.tokenService.audienceFromToken(token);
     await this.feedService.deleteFeed(loginUserId, feedId);
-    return { status: 200, message: 'Feed deledted successfully' };
+    return { status: 204, message: 'Feed deledted successfully' };
   }
 
   @Put('/:feedId')

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -229,7 +229,6 @@ export class FeedService {
         throw new HttpError(404, 'Feed does not exist');
       if (!findFeed.user || findFeed.user.id !== loginUserId)
         throw new HttpError(403, 'Invalid User');
-
       // feedTag들 delete
       if (findFeed.feedTag) {
         findFeed.feedTag.forEach(async (feedTag) => {
@@ -254,14 +253,12 @@ export class FeedService {
           await this.bookmarkRepository.deleteBookmark(bookmark.id);
         });
       };
-
       // feedComment는 softDelete
-      // if (findFeed.feedComment) {
-      //   findFeed.feedComment.forEach(async (comment) => {
-      //     comment.deletedAt = newDate;
-      //     await this.feedCommentRepository.deleteFeedComment(comment);
-      //   });
-      // };
+      if (findFeed.feedComment) {
+        findFeed.feedComment.forEach(async (comment) => {
+          await this.feedCommentRepository.deleteComment(comment.id);
+        });
+      };
       await this.feedRepository.deletedFeed(findFeed);
       await queryRunner.commitTransaction();
     } catch (error) {

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -289,6 +289,21 @@ export class FeedService {
     );
   }
 
+  async deleteComment(
+    loginUserId: number,
+    feedId: number,
+    commentId: number,
+  ): Promise<void> {
+    const existingFeedComment = await this.feedCommentRepository.getCommentById(commentId);
+    if(!existingFeedComment) throw new HttpError(404, 'Comment does not exist');
+    if(existingFeedComment.user.id !== loginUserId) throw new HttpError(403, 'Invalid User');
+    const existingFeed =
+      await this.feedRepository.getFeedWithDetailsById(feedId);
+    if (!existingFeed || existingFeed.deletedAt || !existingFeed.user)
+      throw new HttpError(404, 'Feed does not exist');
+    await this.feedCommentRepository.deleteComment(commentId);
+  }
+
   // 북마크 상태 변경 api : 미사용중
   async handleBookmark(
     loginUserId: number,

--- a/src/feed/feedComment.repository.ts
+++ b/src/feed/feedComment.repository.ts
@@ -43,7 +43,7 @@ export class FeedCommentRepository {
     await this.feedCommentRepository.softDelete(commentId);
   }
 
-  // async updateFeedComment(comment: FeedCommentEntity):Promise<void> {
+  // async updateComment(comment: FeedCommentEntity):Promise<void> {
   //   try{
 
   //   }catch(error){

--- a/src/feed/feedComment.repository.ts
+++ b/src/feed/feedComment.repository.ts
@@ -13,6 +13,17 @@ export class FeedCommentRepository {
     private readonly feedCommentRepository: Repository<FeedCommentEntity>,
   ) {}
 
+  async getCommentById(id: number): Promise<FeedCommentEntity> {
+    const result = await this.feedCommentRepository.findOne({
+      relations:{
+        feed: true,
+        user: true,
+      },
+      where: { id: id },
+    });
+    return result;
+  }
+
   async createComment(
     userId: number,
     feedId: number,
@@ -24,6 +35,12 @@ export class FeedCommentRepository {
       feed: { id: feedId },
     });
     return savedComment;
+  }
+
+  async deleteComment(
+    commentId: number
+  ): Promise<void> {
+    await this.feedCommentRepository.softDelete(commentId);
   }
 
   // async updateFeedComment(comment: FeedCommentEntity):Promise<void> {


### PR DESCRIPTION
## Motivation 🎉
 - 댓글 삭제 API : DELETE /feeds/:feedId/comment/:commentId
   
 - 피드 삭제 시 댓글 삭제
   
![image](https://github.com/team0102/weather-backend/assets/120547603/601c64bf-7c84-4aa3-aab8-44c0ca2e9a22)



## Key Changes 🗝️
 - 에러 핸들링
   ＊ 존재하는 댓글인지 
＊ 댓글 작성자만 삭제 가능
＊ 존재하는 피드인지
＊ 삭제되지 않은 피드인지
＊ 피드 작성자가 탈퇴하지 않았는지
 - 피드 삭제 시 feedComment 삭제
   
