### PR TITLE
feed 내 api 수정

### DIFF
--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -131,7 +131,7 @@ export class FeedController {
     return { status: 204, message: 'Comment deleted successfully' };
   }
 
-  @Post('/like/:feedId')
+  @Post('/:feedId/like')
   async handleFeedLike(
     @Headers('Authorization') token: string,
     @Param('feedId', ParseIntPipe) feedId: number,

--- a/src/feed/feed.repository.ts
+++ b/src/feed/feed.repository.ts
@@ -99,7 +99,7 @@ export class FeedRepository {
     if (Array.isArray(feedImage) && feedImage.length > 0) {
       await Promise.all(
         feedImage.map(async (image) => {
-          await this.feedImageRepository.softDelete(image);
+          await this.feedImageRepository.softDelete(image.id);
         }),
       );
     }


### PR DESCRIPTION
## Motivation 🎉
 - 피드 삭제 시 피드 이미지가 삭제 안되는 오류 수정
   ＊ feedImageRepository.softDelete(image); 에서 image를 image.id 로 수정
 - local과 달리 ec2에서 좋아요 api  실행 시 404 에러 발생
   ＊ 경로 문제인지 테스트 하기 위해서 feeds/like/:feedId 에서 feeds/:feedId/like로 수정.
   ＊ 병합 후 테스트 예정


